### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
     name: E2E Test
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
 
     services:
       postgres:
@@ -107,6 +109,8 @@ jobs:
   security:
     name: セキュリティスキャン
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/k07g/g1/security/code-scanning/2](https://github.com/k07g/g1/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block with least-privilege settings to jobs that currently rely on implicit defaults. In this snippet, that applies to the `e2e` and `security` jobs. They both only need to read the repository contents to run Go tests and vulnerability scans, so `contents: read` is sufficient. There is no indication they need to modify issues, pull requests, or other resources.

The best minimal fix without changing functionality is:

- Under the `e2e` job (around line 71), add:
  ```yaml
  permissions:
    contents: read
  ```
- Under the `security` job (around line 107–110), add:
  ```yaml
  permissions:
    contents: read
  ```

No new imports or dependencies are required; this is purely a YAML configuration change within `.github/workflows/ci.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
